### PR TITLE
adding launched Hong Kong region and some other zones to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@
 | *coming soon* | Bahrain | `...`
 | *coming soon* | Cape Town | `...`
 | *coming soon* | Milan | `...`
+| *coming soon* | Jakarta | `...`
 
 *<sup>1</sup>To ensure that resources are distributed across the Availability Zones for these regions, they may differ for each AWS account. You can run `aws ec2 describe-availability-zones --region $REGION` to be sure which ones are available to you.*  
 *<sup>2</sup>The [US GovCloud](https://aws.amazon.com/govcloud-us/) regions are only available to official U.S. government agencies and organizations.*  

--- a/readme.md
+++ b/readme.md
@@ -15,17 +15,17 @@
 | eu-west-3 | Paris | `eu-west-3a` `eu-west-3b` `eu-west-3c`
 | eu-central-1 | Frankfurt | `eu-central-1a` `eu-central-1b` `eu-central-1c`
 | <sup>1</sup>ap-northeast-1 | Tokyo | `ap-northeast-1a` `ap-northeast-1b` `ap-northeast-1c` `ap-northeast-1d`
-| ap-northeast-2 | Seoul | `ap-northeast-2a` `ap-northeast-2c`
+| ap-northeast-2 | Seoul | `ap-northeast-2a` `ap-northeast-2b` `ap-northeast-2c`
 | <sup>4</sup>ap-northeast-3 | Osaka | `ap-northeast-3a`
 | ap-southeast-1 | Singapore | `ap-southeast-1a` `ap-southeast-1b` `ap-southeast-1c`
 | ap-southeast-2 | Sydney | `ap-southeast-2a` `ap-southeast-2b` `ap-southeast-2c`
-| ap-south-1 | Mumbai | `ap-south-1a` `ap-south-1b`
+| ap-south-1 | Mumbai | `ap-south-1a` `ap-south-1b` `ap-south-1c`
 | <sup>1</sup>sa-east-1 | Sao Paulo | `sa-east-1a` `sa-east-1b` `sa-east-1c`
 | <sup>3</sup>cn-north-1 | Bejing | `cn-north-1a` `cn-north-1b`
 | <sup>3</sup>cn-northwest-1 | Ningxia | `cn-northwest-1a` `cn-northwest-1b` `cn-northwest-1c`
+| ap-east-1 | Hong Kong | `ap-east-1a` `ap-east-1b` `ap-east-1c`
 | *coming soon* | Bahrain | `...`
 | *coming soon* | Cape Town | `...`
-| *coming soon* | Hong Kong SAR | `...`
 | *coming soon* | Milan | `...`
 
 *<sup>1</sup>To ensure that resources are distributed across the Availability Zones for these regions, they may differ for each AWS account. You can run `aws ec2 describe-availability-zones --region $REGION` to be sure which ones are available to you.*  


### PR DESCRIPTION
```
$ aws ec2 describe-regions | pcregrep -o1 '"RegionName": "(.*)"' | xargs -L1 bash -c 'aws ec2 describe-availability-zones --region $0 | grep "ZoneName"'
```